### PR TITLE
feat: add minimalist GitHub issue and discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,11 @@
+---
+title: General Discussion
+labels: ["discussion"]
+---
+
+## Topic
+What would you like to discuss?
+
+## Details
+Share your thoughts, ideas, or questions
+

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,14 @@
+---
+title: Ideas & Suggestions
+labels: ["idea"]
+---
+
+## Idea
+Brief description of your idea
+
+## Use Case
+Who would benefit from this?
+
+## Implementation Thoughts
+Any ideas on how this could be implemented?
+

--- a/.github/DISCUSSION_TEMPLATE/question.yml
+++ b/.github/DISCUSSION_TEMPLATE/question.yml
@@ -1,0 +1,11 @@
+---
+title: Question
+labels: ["question"]
+---
+
+## Question
+What would you like to know?
+
+## Context
+Any additional context or details
+

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,17 @@
+---
+title: Show and Tell
+labels: ["showcase"]
+---
+
+## What did you build?
+Describe what you've created with VeriMeZK
+
+## Share
+- Screenshots
+- Code snippets
+- Links
+- Demo
+
+## Learnings
+What did you learn? Any tips for others?
+

--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,0 +1,8 @@
+---
+name: Blank Issue
+description: Open a blank issue
+title: ""
+labels: []
+assignees: []
+---
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,13 @@
-# Bug Report
+---
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: ["bug"]
+assignees: []
+---
 
 ## Description
-<!-- A clear and concise description of what the bug is -->
+Brief description of the bug
 
 ## Steps to Reproduce
 1. 
@@ -9,23 +15,15 @@
 3. 
 
 ## Expected Behavior
-<!-- What you expected to happen -->
+What should happen
 
 ## Actual Behavior
-<!-- What actually happened -->
+What actually happens
 
 ## Environment
-- **Browser**: <!-- e.g., Chrome 120, Safari 17 -->
-- **OS**: <!-- e.g., macOS 14, Windows 11, iOS 17 -->
-- **VeriMe ZK Version**: <!-- e.g., 1.0.0 -->
-- **Node Version** (if applicable): <!-- e.g., 18.17.0 -->
-
-## Screenshots
-<!-- If applicable, add screenshots to help explain your problem -->
+- Browser: 
+- OS: 
+- Version: 
 
 ## Additional Context
-<!-- Add any other context about the problem here -->
-
-## Possible Solution
-<!-- If you have suggestions on how to fix the bug -->
-
+Any other relevant information

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or Discussion
+    url: https://github.com/UPTODATE-DEV/VeriMeZK/discussions
+    about: Ask questions or start a discussion

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,17 @@
+---
+name: Documentation
+description: Documentation improvement or request
+title: "[DOC] "
+labels: ["documentation"]
+assignees: []
+---
+
+## Description
+What documentation needs to be added or improved?
+
+## Location
+Where should this documentation be added?
+
+## Content
+What should be documented?
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,19 @@
-# Feature Request
+---
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[FEAT] "
+labels: ["enhancement"]
+assignees: []
+---
 
-## Is your feature request related to a problem?
-<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+## Description
+Brief description of the feature
 
-## Describe the solution you'd like
-<!-- A clear and concise description of what you want to happen -->
+## Problem
+What problem does this solve?
 
-## Describe alternatives you've considered
-<!-- A clear and concise description of any alternative solutions or features you've considered -->
-
-## Use Case
-<!-- Describe the use case for this feature. Who would benefit from it? -->
+## Solution
+Proposed solution or approach
 
 ## Additional Context
-<!-- Add any other context, mockups, or examples about the feature request here -->
-
-## Implementation Ideas
-<!-- If you have ideas on how this could be implemented -->
-
+Any other relevant information


### PR DESCRIPTION
Add minimalist GitHub issue and discussion templates to improve community engagement and issue organization.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
<!-- Link related issues here -->
N/A

## Changes Made
- Added minimalist bug report template
- Added minimalist feature request template
- Added documentation issue template
- Added blank issue template for open-ended issues
- Added `config.yml` to organize templates in GitHub UI
- Added discussion templates (question, general, ideas, show-and-tell)
- Enabled blank issues and linked to discussions

## Testing
- [x] Templates validated for proper YAML front matter
- [x] Templates tested for GitHub compatibility
- [ ] Tests pass locally
- [ ] Added/updated tests for new functionality
- [ ] Tested on multiple browsers
- [ ] Tested on mobile devices (if appli